### PR TITLE
don’t use absolute paths

### DIFF
--- a/lib/sync_readme/confluence_sync.rb
+++ b/lib/sync_readme/confluence_sync.rb
@@ -19,13 +19,13 @@ module SyncReadme
     end
 
     def get_page
-      response = @client.get("/rest/api/content/#{@page_id}", expand: 'body.view,version')
+      response = @client.get("rest/api/content/#{@page_id}", expand: 'body.view,version')
       JSON.parse(response.body)
     end
 
     def update(params)
       @client.put do |request|
-        request.url "/rest/api/content/#{@page_id}"
+        request.url "rest/api/content/#{@page_id}"
         request.headers['Content-Type'] = 'application/json'
         request.body = params.to_json
       end

--- a/spec/sync_readme/confluence_sync_spec.rb
+++ b/spec/sync_readme/confluence_sync_spec.rb
@@ -21,7 +21,7 @@ describe SyncReadme::ConfluenceSync do
 
   describe "#get_page" do
     it 'calls get on the client' do
-      expect_any_instance_of(Faraday::Connection).to receive(:get).with("/rest/api/content/12345", expand: 'body.view,version').and_return(response)
+      expect_any_instance_of(Faraday::Connection).to receive(:get).with("rest/api/content/12345", expand: 'body.view,version').and_return(response)
       subject.get_page
     end
   end


### PR DESCRIPTION
Gem doesn't work if you're using hosted confluence, e.g. `https://company.atlassian.net/wiki` because of the leading `/` in API endpoints. (see https://github.com/lostisland/faraday/issues/293)

