### PR TITLE
nudge people towards using API tokens instead of passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ readme:
   password: bar                     # optional, generally better as an environment variable
   notice: this file is sync'd!      # optional, adds the notice (as html) to the top of the confluance docs
   strip_title: false                # optional, defaults false, strips the first h1 (#) tag from the file
-  syntax_highlighting: true         # optional, defaults true, uses coderay sytax highlighting on code blocks
+  syntax_highlighting: true         # optional, defaults true, uses coderay syntax highlighting on code blocks
 ```
 
 You'll also need to set environment variables with credentials to update the page in question:
+
+The Atlassian Cloud supports [API tokens](https://confluence.atlassian.com/cloud/api-tokens-938839638.html), which can be used for `CONFLUENCE_PASSWORD`
 
 ```
 CONFLUENCE_USERNAME=jsmith
@@ -52,8 +54,8 @@ sync_readme [configuration]
 2. If you haven't already, create the pages you want to sync to on confluence and get their IDs.
 3. Create your `.sync_readme.yml` file like the one above (or see the example)
 4. Add `gem 'sync_readme'` to your apps gemfile
-5. Set `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD` as CI Variables. 
-6. Add the following job to your .gitlab-ci.yml 
+5. Set `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD` as CI Variables.
+6. Add the following job to your .gitlab-ci.yml
    ``` yaml
    Sync To Confluence:
      stage: update_docs                # Replace that with the stage you want this to run


### PR DESCRIPTION
they work just fine, in cloud wiki at least